### PR TITLE
fix: correct spelling of "Summarize" to "Summarizer" in Home component

### DIFF
--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -201,7 +201,7 @@ function Home() {
                   aria-label="Try Content Summarizer"
                    >
                   <span className="flex items-center gap-2">
-                                  Try Content Summarize <FaArrowRight size={14} />
+                                  Try Content Summarizer <FaArrowRight size={14} />
                   </span>
                 </Link>
 


### PR DESCRIPTION
---
name: Fix: correct spelling of "Summarize" to "Summarizer" in Home component

## 📌 Linked Issue
<!-- Link to the issue this PR addresses (e.g. "Closes #123" or "Related to #456") -->
- [x] Connected to #63 
---

## 🛠 Changes Made
<!-- Bullet-point summary of your changes -->
- Fixed: Typo of summarize to summarizer

