### PR TITLE
Fixed Testimonials Header issue

### DIFF
--- a/Frontend/src/components/Testimonials.jsx
+++ b/Frontend/src/components/Testimonials.jsx
@@ -181,7 +181,7 @@ const Testimonials = forwardRef((props, ref) => {
                 <FaStar className="text-yellow-400 text-3xl" />
               </div>
             </div>
-            <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold mb-3 sm:mb-4 bg-gradient-to-r from-blue-600 to-indigo-600 dark:bg-gradient-to-r dark:from-purple-400 dark:to-blue-400 bg-clip-text text-transparent">
+            <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold mb-3 py-2 sm:mb-4 bg-gradient-to-r from-blue-600 to-indigo-600 dark:bg-gradient-to-r dark:from-purple-400 dark:to-blue-400 bg-clip-text text-transparent">
               What Developers Say
             </h2>
             <p className={`text-sm sm:text-base md:text-lg ${


### PR DESCRIPTION
Pull Request

## 📌 Linked Issue
<!-- Link to the issue this PR addresses (e.g. "Closes #123" or "Related to #456") -->
- Closes the issue [Testimonials header text cropped #142](https://github.com/Roshansuthar1105/Omex/issues/142)
---

## 🛠 Changes Made
<!-- Bullet-point summary of your changes -->
- The Testimonials header was cropped out partially, fixed it by adding padding.

---
## 🧪 Testing
<!-- How did you verify your changes? -->
- [ ] Ran unit tests (`npm test`)
- [ ] Tested manually (describe below):
  - Test case 1: [Steps + Expected Result]
  - Test case 2: [Steps + Expected Result]

---
## 📸 UI Changes (if applicable)
<!-- Before/after screenshots or GIFs -->
<img width="1919" height="364" alt="image" src="https://github.com/user-attachments/assets/ad11c825-e12e-450e-92cf-0350286fa33b" />
