### PR TITLE
Bug: Git command still alwyz apper in dark mode fixed

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1558,6 +1558,62 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",

--- a/Frontend/src/pages/ContributorGuide.jsx
+++ b/Frontend/src/pages/ContributorGuide.jsx
@@ -290,29 +290,42 @@ const ContributorGuide = () => {
 
         {/* Git Commands Cheat Sheet */}
         <section className="mb-16">
-          <h2 className={`text-3xl font-bold mb-8 text-center ${isDark ? 'text-white' : 'text-gray-800'
-            }`}>
+          <h2 className={`text-3xl font-bold mb-8 text-center ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>
             Essential Git Commands
           </h2>
-          <div className="bg-gray-900 rounded-xl p-4 md:p-6 shadow-xl border border-gray-700">
-            <div className="space-y-4">
-              {commands.map((cmd) => (
-                <div key={cmd.id} className="bg-gray-950 rounded-lg p-3 md:p-4 border border-gray-700">
-                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
-                    <h4 className="text-blue-400 font-semibold text-sm md:text-base">{cmd.title}</h4>
-                    <button
-                      onClick={() => copyToClipboard(cmd.command, cmd.id)}
-                      className="bg-gray-700 hover:bg-gray-600 text-white flex items-center justify-center space-x-2 px-3 py-2 rounded text-sm transition-all duration-300 hover:scale-105 self-start sm:self-center"
-                    >
-                      {copiedCommand === cmd.id ? <FaCheck className="w-4 h-4" /> : <FaCopy className="w-4 h-4" />}
-                      <span>{copiedCommand === cmd.id ? 'Copied!' : 'Copy'}</span>
-                    </button>
-                  </div>
-                  <code className="text-blue-400 block mb-2 font-mono text-sm md:text-base break-all">{cmd.command}</code>
-                  <p className="text-gray-400 text-xs md:text-sm">{cmd.description}</p>
+          <div className="space-y-4">
+            {commands.map((cmd) => (
+              <div
+                key={cmd.id}
+                className={`rounded-2xl p-5 md:p-6 shadow-lg border transition-all duration-300
+                  ${isDark
+                    ? 'bg-[#1e293b] border-[#334155] hover:bg-[#111827]'
+                    : 'bg-white border-gray-200 hover:bg-blue-50'}`}
+              >
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-2">
+                  <h4 className={`font-bold text-lg md:text-xl ${isDark ? 'text-white' : 'text-black'}`}>
+                    {cmd.title}
+                  </h4>
+                  <button
+                    onClick={() => copyToClipboard(cmd.command, cmd.id)}
+                    className={`flex items-center justify-center space-x-2 px-3 py-2 rounded transition-all duration-300 font-medium
+                      ${isDark
+                        ? 'bg-gray-800 border border-gray-700 text-gray-100 hover:bg-gray-700'
+                        : 'bg-blue-100 border border-blue-200 text-blue-700 hover:bg-blue-200'}`}
+                  >
+                    {copiedCommand === cmd.id ? <FaCheck className="w-4 h-4" /> : <FaCopy className="w-4 h-4" />}
+                    <span>{copiedCommand === cmd.id ? 'Copied!' : 'Copy'}</span>
+                  </button>
                 </div>
-              ))}
-            </div>
+                <code
+                  className={`block mb-2 font-mono px-2 py-1 rounded text-base break-words
+                    ${isDark ? 'bg-[#334155] text-blue-200' : 'bg-gray-100 text-blue-700'}`}
+                >
+                  {cmd.command}
+                </code>
+                <p className={`text-sm ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>{cmd.description}</p>
+              </div>
+            ))}
           </div>
         </section>
 


### PR DESCRIPTION
---
name: "📦 Pull Request"
about: Submit changes for review
title: "PR: **Improve Git Command Section UI Consistency and Readability**"
labels: "enhancement, ui, gssoc'25 , level2"
assignees: "Sejal-collection"
---

## 📌 Linked Issue

- [x] Connected to #223
---

## 🛠 Changes Made

- Added: Theme-adaptive card style for Git command section
- Fixed:  Git command card titles now use bold black in light mode, bold white in dark mode
- Updated: Readability and contrast for command code and buttons

---
## 🧪 Testing

- [x] Tested manually (describe below):
  - Test case 1: Switched between light/dark theme and verified correct text and background contrast
  - Test case 2: Checked copy button and clipboard function for all git commands
---
## 📸 UI Changes (if applicable)

| Before | : 

<img width="1407" height="861" alt="492041843-d2a84ab6-a9ed-4df5-9df3-f8cb940a255d" src="https://github.com/user-attachments/assets/80b61635-1815-4b3c-b2bc-3ea44f636e20" />

| After | : 

https://github.com/user-attachments/assets/a80a4146-2d70-49da-b410-08b28137883a


---
## 📝 Documentation Updates

- [x] Added code comments
---

## ✅ Checklist
- [x] Created a new branch for PR
- [x] Have stared the repository
- [x] Follows [JavaScript Styleguide](CONTRIBUTING.md#javascript-styleguide)
- [x] No console warnings/errors
- [x] Commit messages follow [Git Guidelines](CONTRIBUTING.md#git-commit-messages)

## 💡 Additional Notes (If any)
- No breaking changes. UI improvement only.
- All changes reviewed and tested for both themes.
